### PR TITLE
Updating headings for a11y

### DIFF
--- a/includes/adminpages/profile.php
+++ b/includes/adminpages/profile.php
@@ -14,7 +14,7 @@ function pmproava_show_extra_profile_fields( $user ) {
 
 	// Show the shipping fields if the membership level includes fields or the user is an admin.
 	if ( current_user_can( 'manage_options' ) ) { ?>
-	    <h3><?php esc_html_e( 'PMPro AvaTax', 'pmpro-avatax' ); ?></h3>
+	    <h2><?php esc_html_e( 'PMPro AvaTax', 'pmpro-avatax' ); ?></h2>
         <?php if ( $pmpro_avatax->check_credentials() ) { ?>
             <table class="form-table">
                 <tr>

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -18,7 +18,7 @@ function pmproava_checkout_boxes() {
 	if ( $show_checkout_options ) {
 		?>
 		<div class="pmpro_checkout">
-			<h3><span class="pmpro_checkout-h3-name"><?php _e( 'Tax', 'pmpro-avatax' ); ?></span></h3>
+			<h2><span class="pmpro_checkout-h2-name"><?php _e( 'Tax', 'pmpro-avatax' ); ?></span></h2>
 			<div class="pmpro_checkout-fields">
 			<?php if ( $show_vat_fields ) { ?>
 				<div id="pmproava_have_vat_number" class="pmpro_checkout-field pmpro_checkout-field-checkbox pmpro_checkout-field-pmproava_show_vat">


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.